### PR TITLE
feat: allow autoloading of named exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ yarn add awilix-router-core
 
 The end-user of the routing library will be able to use decorators or a builder pattern to declaratively set up their routes, middleware and methods.
 
+**Note**: in the examples below, an ES6 `default` export is used, but named exports and multiple exports
+per file are supported.
+
 ## With decorators
 
 ```js

--- a/__fixtures__/mixedExports.js
+++ b/__fixtures__/mixedExports.js
@@ -1,0 +1,9 @@
+const { createController } = require('../src/controller')
+
+class MixedDefaultExportClass {}
+MixedDefaultExportClass.isMixedDefaultExport = true
+module.exports.default = createController(MixedDefaultExportClass)
+
+class MixedNamedExportClass {}
+MixedNamedExportClass.isMixedNamedExport = true
+module.exports.MixedNamedExportClass = createController(MixedNamedExportClass)

--- a/__fixtures__/mixedModuleExports.js
+++ b/__fixtures__/mixedModuleExports.js
@@ -1,0 +1,13 @@
+const { createController } = require('../src/controller')
+
+class MixedModuleExportsClass {}
+MixedModuleExportsClass.isMixedModuleExports = true
+module.exports = createController(MixedModuleExportsClass)
+
+class MixedModuleDefaultExportClass {}
+MixedModuleDefaultExportClass.isMixedModuleDefaultExport = true
+module.exports.default = createController(MixedModuleDefaultExportClass)
+
+class MixedModuleNamedExportClass {}
+MixedModuleNamedExportClass.isMixedModuleNamedExport = true
+module.exports.MixedModuleNamedExportClass = createController(MixedModuleNamedExportClass)

--- a/__fixtures__/moduleNoneExports.js
+++ b/__fixtures__/moduleNoneExports.js
@@ -1,0 +1,1 @@
+module.exports = null

--- a/__fixtures__/namedExport.js
+++ b/__fixtures__/namedExport.js
@@ -1,0 +1,5 @@
+const { createController } = require('../src/controller')
+
+class NamedExportClass {}
+NamedExportClass.isNamedExport = true
+module.exports.NamedExportClass = createController(NamedExportClass)

--- a/src/__tests__/find-controllers.test.ts
+++ b/src/__tests__/find-controllers.test.ts
@@ -5,8 +5,30 @@ describe('findControllers', () => {
     const result = findControllers('__fixtures__/*.js', { absolute: true })
     const moduleExports = result.find((x: any) => x.target.isModuleExports)
     const defaultExports = result.find((x: any) => x.target.isDefaultExport)
-    expect(result.length).toBe(2)
+    const namedExports = result.find((x: any) => x.target.isNamedExport)
+    const mixedDefaultExports = result.find(
+      (x: any) => x.target.isMixedDefaultExport
+    )
+    const mixedNamedExports = result.find(
+      (x: any) => x.target.isMixedNamedExport
+    )
+    const mixedModuleExports = result.find(
+      (x: any) => x.target.isMixedModuleExports
+    )
+    const mixedModuleDefaultExports = result.find(
+      (x: any) => x.target.isMixedModuleDefaultExport
+    )
+    const mixedModuleNamedExports = result.find(
+      (x: any) => x.target.isMixedModuleNamedExport
+    )
+    expect(result.length).toBe(6)
     expect(typeof (moduleExports as any).target).toBe('function')
     expect(typeof (defaultExports as any).target).toBe('function')
+    expect(typeof (namedExports as any).target).toBe('function')
+    expect(typeof (mixedDefaultExports as any).target).toBe('function')
+    expect(typeof (mixedNamedExports as any).target).toBe('function')
+    expect(typeof (mixedModuleExports as any).target).toBe('function')
+    expect(mixedModuleDefaultExports).toBeUndefined()
+    expect(mixedModuleNamedExports).toBeUndefined()
   })
 })


### PR DESCRIPTION
Hi, it's me again.

This implements the same functionality as in https://github.com/jeffijoe/awilix/pull/115.

There's nothing to do in `awilix-express` except probably bump the dependency in `package.json` and perhaps update the test and examples, if you want to.

I chose to mirror the implementation from `awilix` concerning which exports get loaded. Let me know what you think.