### PR TITLE
Update find-controllers to handle ESM modules runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
   - [Extracting route config](#extracting-route-config)
     - [`getStateAndTarget(functionOrClassOrController)`](#getstateandtargetfunctionorclassorcontroller)
     - [`rollUpState(state)`](#rollupstatestate)
-    - [`findControllers(pattern, globOptions)`](#findcontrollerspattern-globoptions)
+    - [`findControllers(pattern, opts)`](#findcontrollerspattern-opts)
 - [Author](#author)
 
 # Install
@@ -295,13 +295,13 @@ Given a controller (either from `createController` or a decorated class), return
 
 This will return a map where the key is the controller method name and the value is the routing config to set up for that method, with root paths + middleware stacks pre-merged.
 
-### `findControllers(pattern, globOptions)`
+### `findControllers(pattern, opts)`
 
 Using `fast-glob`, loads controllers from matched files.
 
-> Note: This uses `require` and so currently is not compatible with ESM.
+`opts` is a merge of glob options to pass into glob for pattern matching and the `esModules` property which, when set to `true` returns a `Promise` that loads controller modules via dynamic `import()` (for async/ ES modules usage).
 
-Returns an array of state-target tuples.
+Returns an array (or a `Promise` that resolves to an array) of state-target tuples.
 
 # Author
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7130,21 +7130,14 @@
     },
     "node_modules/npm/node_modules/@colors/colors": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.1.90"
       }
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7161,9 +7154,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7175,15 +7165,11 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7200,9 +7186,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7217,13 +7200,11 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "2.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7239,7 +7220,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "7.3.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7286,7 +7266,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "8.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7305,7 +7284,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7317,7 +7295,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7332,7 +7309,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7344,7 +7320,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "5.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7363,7 +7338,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7379,7 +7353,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7394,7 +7367,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7409,7 +7381,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7418,7 +7389,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7427,7 +7397,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7445,7 +7414,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "7.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7457,7 +7425,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7469,7 +7436,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "7.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7485,19 +7451,14 @@
     },
     "node_modules/npm/node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
       "version": "2.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7509,7 +7470,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/core": {
       "version": "0.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -7518,7 +7478,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -7527,7 +7486,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
       "version": "2.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7542,7 +7500,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
       "version": "2.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7555,7 +7512,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
       "version": "0.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7569,7 +7525,6 @@
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7578,7 +7533,6 @@
     },
     "node_modules/npm/node_modules/@tufjs/models": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7591,7 +7545,6 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7600,9 +7553,6 @@
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7614,7 +7564,6 @@
     },
     "node_modules/npm/node_modules/aggregate-error": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7627,9 +7576,6 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7638,9 +7584,6 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7652,20 +7595,16 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7674,13 +7613,11 @@
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "4.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7695,7 +7632,6 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7704,9 +7640,6 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7715,7 +7648,6 @@
     },
     "node_modules/npm/node_modules/builtins": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7724,7 +7656,6 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "18.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7747,9 +7678,6 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7761,7 +7689,6 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7770,7 +7697,6 @@
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "4.0.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7785,7 +7711,6 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "4.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -7797,7 +7722,6 @@
     },
     "node_modules/npm/node_modules/clean-stack": {
       "version": "2.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7806,7 +7730,6 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7819,9 +7742,6 @@
     },
     "node_modules/npm/node_modules/cli-table3": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
-      "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7836,8 +7756,6 @@
     },
     "node_modules/npm/node_modules/clone": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7846,7 +7764,6 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7855,9 +7772,6 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7869,15 +7783,11 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/color-support": {
       "version": "1.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -7886,7 +7796,6 @@
     },
     "node_modules/npm/node_modules/columnify": {
       "version": "1.6.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7899,22 +7808,16 @@
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7928,7 +7831,6 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7943,7 +7845,6 @@
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -7955,9 +7856,6 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7974,13 +7872,11 @@
     },
     "node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/defaults": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7992,7 +7888,6 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "5.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -8001,33 +7896,24 @@
     },
     "node_modules/npm/node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -8036,19 +7922,16 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -8057,9 +7940,6 @@
     },
     "node_modules/npm/node_modules/foreground-child": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8075,7 +7955,6 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8087,9 +7966,6 @@
     },
     "node_modules/npm/node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -8098,7 +7974,6 @@
     },
     "node_modules/npm/node_modules/gauge": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8117,9 +7992,6 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8141,19 +8013,16 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hasown": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8165,9 +8034,6 @@
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
-      "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8179,13 +8045,11 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8198,7 +8062,6 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "7.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8211,10 +8074,8 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -8224,7 +8085,6 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "6.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8236,9 +8096,6 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -8247,7 +8104,6 @@
     },
     "node_modules/npm/node_modules/indent-string": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -8256,7 +8112,6 @@
     },
     "node_modules/npm/node_modules/ini": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -8265,7 +8120,6 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8283,13 +8137,11 @@
     },
     "node_modules/npm/node_modules/ip": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -8301,7 +8153,6 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "5.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -8313,9 +8164,6 @@
     },
     "node_modules/npm/node_modules/is-core-module": {
       "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8327,9 +8175,6 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -8338,23 +8183,16 @@
     },
     "node_modules/npm/node_modules/is-lambda": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -8372,7 +8210,6 @@
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -8381,7 +8218,6 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -8390,7 +8226,6 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -8399,19 +8234,16 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "8.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8424,7 +8256,6 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "6.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8444,7 +8275,6 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "7.0.7",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8466,7 +8296,6 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "5.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8478,7 +8307,6 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "10.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8491,7 +8319,6 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8504,7 +8331,6 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "6.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8519,7 +8345,6 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "9.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8538,7 +8363,6 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "7.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8550,7 +8374,6 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8563,7 +8386,6 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "5.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8579,7 +8401,6 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "10.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -8588,7 +8409,6 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "13.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8610,9 +8430,6 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8627,9 +8444,6 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -8638,7 +8452,6 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8650,7 +8463,6 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8667,7 +8479,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8679,7 +8490,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8691,7 +8501,6 @@
     },
     "node_modules/npm/node_modules/minipass-json-stream": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8701,7 +8510,6 @@
     },
     "node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8713,7 +8521,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8725,7 +8532,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8737,7 +8543,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8749,7 +8554,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8761,7 +8565,6 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8774,7 +8577,6 @@
     },
     "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8786,7 +8588,6 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -8798,13 +8599,11 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -8813,7 +8612,6 @@
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "0.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -8822,7 +8620,6 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "10.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8846,7 +8643,6 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "7.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8861,9 +8657,6 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
-      "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -8878,7 +8671,6 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -8887,7 +8679,6 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8899,7 +8690,6 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "6.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -8911,7 +8701,6 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -8920,7 +8709,6 @@
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "11.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8935,7 +8723,6 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "8.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8947,7 +8734,6 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "9.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8962,7 +8748,6 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "9.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8975,7 +8760,6 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "16.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8993,7 +8777,6 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -9002,7 +8785,6 @@
     },
     "node_modules/npm/node_modules/npmlog": {
       "version": "7.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9017,7 +8799,6 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9032,7 +8813,6 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "17.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9064,7 +8844,6 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9078,9 +8857,6 @@
     },
     "node_modules/npm/node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9089,9 +8865,6 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
-      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -9107,7 +8880,6 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "6.0.15",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9120,7 +8892,6 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9129,7 +8900,6 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -9138,7 +8908,6 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -9147,14 +8916,11 @@
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9167,7 +8933,6 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9179,8 +8944,6 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
-      "dev": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -9188,7 +8951,6 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9200,7 +8962,6 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9209,7 +8970,6 @@
     },
     "node_modules/npm/node_modules/read-package-json": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9224,7 +8984,6 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9237,9 +8996,6 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9248,14 +9004,11 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.5.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9270,7 +9023,6 @@
     },
     "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9282,17 +9034,11 @@
     },
     "node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9304,9 +9050,6 @@
     },
     "node_modules/npm/node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9315,9 +9058,6 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9329,7 +9069,6 @@
     },
     "node_modules/npm/node_modules/sigstore": {
       "version": "2.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9346,7 +9085,6 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9356,7 +9094,6 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9370,7 +9107,6 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "8.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9384,9 +9120,6 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9396,15 +9129,11 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9414,13 +9143,11 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.16",
-      "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "10.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9432,9 +9159,6 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9449,9 +9173,6 @@
     "node_modules/npm/node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9465,9 +9186,6 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9480,9 +9198,6 @@
     "node_modules/npm/node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9494,7 +9209,6 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "9.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9506,7 +9220,6 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9523,7 +9236,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9535,7 +9247,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9547,7 +9258,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9556,21 +9266,16 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9579,7 +9284,6 @@
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "2.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9593,7 +9297,6 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9605,7 +9308,6 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9617,15 +9319,11 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9635,7 +9333,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9647,14 +9344,11 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/wcwidth": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9663,7 +9357,6 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9678,7 +9371,6 @@
     },
     "node_modules/npm/node_modules/which/node_modules/isexe": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9687,7 +9379,6 @@
     },
     "node_modules/npm/node_modules/wide-align": {
       "version": "1.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9696,9 +9387,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9716,9 +9404,6 @@
     "node_modules/npm/node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9735,7 +9420,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9750,9 +9434,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9764,15 +9445,11 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9789,9 +9466,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9806,7 +9480,6 @@
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9819,9 +9492,6 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -17487,18 +17157,11 @@
       "dependencies": {
         "@colors/colors": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-          "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "@isaacs/cliui": {
           "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-          "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "string-width": "^5.1.2",
             "string-width-cjs": "npm:string-width@^4.2.0",
@@ -17510,22 +17173,15 @@
           "dependencies": {
             "ansi-regex": {
               "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-              "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "emoji-regex": {
               "version": "9.2.2",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-              "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "string-width": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "eastasianwidth": "^0.2.0",
                 "emoji-regex": "^9.2.2",
@@ -17534,10 +17190,7 @@
             },
             "strip-ansi": {
               "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-              "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "ansi-regex": "^6.0.1"
               }
@@ -17546,13 +17199,11 @@
         },
         "@isaacs/string-locale-compare": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "@npmcli/agent": {
           "version": "2.2.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "agent-base": "^7.1.0",
             "http-proxy-agent": "^7.0.0",
@@ -17564,7 +17215,6 @@
         "@npmcli/arborist": {
           "version": "7.3.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@isaacs/string-locale-compare": "^1.1.0",
             "@npmcli/fs": "^3.1.0",
@@ -17604,7 +17254,6 @@
         "@npmcli/config": {
           "version": "8.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@npmcli/map-workspaces": "^3.0.2",
             "ci-info": "^4.0.0",
@@ -17619,7 +17268,6 @@
         "@npmcli/disparity-colors": {
           "version": "3.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.3.0"
           },
@@ -17627,7 +17275,6 @@
             "ansi-styles": {
               "version": "4.3.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "color-convert": "^2.0.1"
               }
@@ -17637,7 +17284,6 @@
         "@npmcli/fs": {
           "version": "3.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "semver": "^7.3.5"
           }
@@ -17645,7 +17291,6 @@
         "@npmcli/git": {
           "version": "5.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@npmcli/promise-spawn": "^7.0.0",
             "lru-cache": "^10.0.1",
@@ -17660,7 +17305,6 @@
         "@npmcli/installed-package-contents": {
           "version": "2.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "npm-bundled": "^3.0.0",
             "npm-normalize-package-bin": "^3.0.0"
@@ -17669,7 +17313,6 @@
         "@npmcli/map-workspaces": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@npmcli/name-from-folder": "^2.0.0",
             "glob": "^10.2.2",
@@ -17680,7 +17323,6 @@
         "@npmcli/metavuln-calculator": {
           "version": "7.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "cacache": "^18.0.0",
             "json-parse-even-better-errors": "^3.0.0",
@@ -17690,18 +17332,15 @@
         },
         "@npmcli/name-from-folder": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "@npmcli/node-gyp": {
           "version": "3.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "@npmcli/package-json": {
           "version": "5.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@npmcli/git": "^5.0.0",
             "glob": "^10.2.2",
@@ -17715,7 +17354,6 @@
         "@npmcli/promise-spawn": {
           "version": "7.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "which": "^4.0.0"
           }
@@ -17723,7 +17361,6 @@
         "@npmcli/query": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "postcss-selector-parser": "^6.0.10"
           }
@@ -17731,7 +17368,6 @@
         "@npmcli/run-script": {
           "version": "7.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@npmcli/node-gyp": "^3.0.0",
             "@npmcli/package-json": "^5.0.0",
@@ -17742,34 +17378,26 @@
         },
         "@pkgjs/parseargs": {
           "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-          "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "@sigstore/bundle": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@sigstore/protobuf-specs": "^0.2.1"
           }
         },
         "@sigstore/core": {
           "version": "0.2.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "@sigstore/protobuf-specs": {
           "version": "0.2.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "@sigstore/sign": {
           "version": "2.2.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@sigstore/bundle": "^2.1.1",
             "@sigstore/core": "^0.2.0",
@@ -17780,7 +17408,6 @@
         "@sigstore/tuf": {
           "version": "2.3.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@sigstore/protobuf-specs": "^0.2.1",
             "tuf-js": "^2.2.0"
@@ -17789,7 +17416,6 @@
         "@sigstore/verify": {
           "version": "0.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@sigstore/bundle": "^2.1.1",
             "@sigstore/core": "^0.2.0",
@@ -17798,13 +17424,11 @@
         },
         "@tufjs/canonical-json": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "@tufjs/models": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@tufjs/canonical-json": "2.0.0",
             "minimatch": "^9.0.3"
@@ -17812,15 +17436,11 @@
         },
         "abbrev": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "agent-base": {
           "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "debug": "^4.3.4"
           }
@@ -17828,7 +17448,6 @@
         "aggregate-error": {
           "version": "3.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "clean-stack": "^2.0.0",
             "indent-string": "^4.0.0"
@@ -17836,43 +17455,31 @@
         },
         "ansi-regex": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ansi-styles": {
           "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "aproba": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "4.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "balanced-match": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "bin-links": {
           "version": "4.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "cmd-shim": "^6.0.0",
             "npm-normalize-package-bin": "^3.0.0",
@@ -17882,15 +17489,11 @@
         },
         "binary-extensions": {
           "version": "2.2.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
@@ -17898,7 +17501,6 @@
         "builtins": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "semver": "^7.0.0"
           }
@@ -17906,7 +17508,6 @@
         "cacache": {
           "version": "18.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@npmcli/fs": "^3.1.0",
             "fs-minipass": "^3.0.0",
@@ -17924,38 +17525,30 @@
         },
         "chalk": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "chownr": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ci-info": {
           "version": "4.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "cidr-regex": {
           "version": "4.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ip-regex": "^5.0.0"
           }
         },
         "clean-stack": {
           "version": "2.2.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "cli-columns": {
           "version": "4.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "string-width": "^4.2.3",
             "strip-ansi": "^6.0.1"
@@ -17963,10 +17556,7 @@
         },
         "cli-table3": {
           "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
-          "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@colors/colors": "1.5.0",
             "string-width": "^4.2.0"
@@ -17974,41 +17564,30 @@
         },
         "clone": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "cmd-shim": {
           "version": "6.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "color-support": {
           "version": "1.1.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "columnify": {
           "version": "1.6.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "strip-ansi": "^6.0.1",
             "wcwidth": "^1.0.0"
@@ -18016,21 +17595,15 @@
         },
         "common-ancestor-path": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "cross-spawn": {
           "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -18040,7 +17613,6 @@
             "which": {
               "version": "2.0.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "isexe": "^2.0.0"
               }
@@ -18049,88 +17621,66 @@
         },
         "cssesc": {
           "version": "3.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "debug": {
           "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ms": "2.1.2"
           },
           "dependencies": {
             "ms": {
               "version": "2.1.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "defaults": {
           "version": "1.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "clone": "^1.0.2"
           }
         },
         "diff": {
           "version": "5.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "eastasianwidth": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-          "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "encoding": {
           "version": "0.1.13",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "iconv-lite": "^0.6.2"
           }
         },
         "env-paths": {
           "version": "2.2.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "err-code": {
           "version": "2.0.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "exponential-backoff": {
           "version": "3.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "fastest-levenshtein": {
           "version": "1.0.16",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "foreground-child": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-          "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
             "signal-exit": "^4.0.1"
@@ -18139,22 +17689,17 @@
         "fs-minipass": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minipass": "^7.0.3"
           }
         },
         "function-bind": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "gauge": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^1.0.3 || ^2.0.0",
             "color-support": "^1.1.3",
@@ -18168,10 +17713,7 @@
         },
         "glob": {
           "version": "10.3.10",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-          "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "foreground-child": "^3.1.0",
             "jackspeak": "^2.3.5",
@@ -18182,41 +17724,33 @@
         },
         "graceful-fs": {
           "version": "4.2.11",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "hasown": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "function-bind": "^1.1.2"
           }
         },
         "hosted-git-info": {
           "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
-          "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "lru-cache": "^10.0.1"
           }
         },
         "http-cache-semantics": {
           "version": "4.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "http-proxy-agent": {
           "version": "7.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "agent-base": "^7.1.0",
             "debug": "^4.3.4"
@@ -18225,7 +17759,6 @@
         "https-proxy-agent": {
           "version": "7.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "agent-base": "^7.0.2",
             "debug": "4"
@@ -18234,8 +17767,6 @@
         "iconv-lite": {
           "version": "0.6.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -18243,32 +17774,25 @@
         "ignore-walk": {
           "version": "6.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minimatch": "^9.0.0"
           }
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "indent-string": {
           "version": "4.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ini": {
           "version": "4.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "init-package-json": {
           "version": "6.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "npm-package-arg": "^11.0.0",
             "promzard": "^1.0.0",
@@ -18281,57 +17805,41 @@
         },
         "ip": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ip-regex": {
           "version": "5.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "is-cidr": {
           "version": "5.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "cidr-regex": "4.0.3"
           }
         },
         "is-core-module": {
           "version": "2.13.1",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-          "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "hasown": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "is-lambda": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "jackspeak": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-          "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@isaacs/cliui": "^8.0.2",
             "@pkgjs/parseargs": "^0.11.0"
@@ -18339,33 +17847,27 @@
         },
         "json-parse-even-better-errors": {
           "version": "3.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "json-stringify-nice": {
           "version": "1.1.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "just-diff": {
           "version": "6.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "just-diff-apply": {
           "version": "5.5.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "libnpmaccess": {
           "version": "8.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "npm-package-arg": "^11.0.1",
             "npm-registry-fetch": "^16.0.0"
@@ -18374,7 +17876,6 @@
         "libnpmdiff": {
           "version": "6.0.6",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@npmcli/arborist": "^7.2.1",
             "@npmcli/disparity-colors": "^3.0.0",
@@ -18390,7 +17891,6 @@
         "libnpmexec": {
           "version": "7.0.7",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@npmcli/arborist": "^7.2.1",
             "@npmcli/run-script": "^7.0.2",
@@ -18408,7 +17908,6 @@
         "libnpmfund": {
           "version": "5.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@npmcli/arborist": "^7.2.1"
           }
@@ -18416,7 +17915,6 @@
         "libnpmhook": {
           "version": "10.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "npm-registry-fetch": "^16.0.0"
@@ -18425,7 +17923,6 @@
         "libnpmorg": {
           "version": "6.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "npm-registry-fetch": "^16.0.0"
@@ -18434,7 +17931,6 @@
         "libnpmpack": {
           "version": "6.0.6",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@npmcli/arborist": "^7.2.1",
             "@npmcli/run-script": "^7.0.2",
@@ -18445,7 +17941,6 @@
         "libnpmpublish": {
           "version": "9.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ci-info": "^4.0.0",
             "normalize-package-data": "^6.0.0",
@@ -18460,7 +17955,6 @@
         "libnpmsearch": {
           "version": "7.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "npm-registry-fetch": "^16.0.0"
           }
@@ -18468,7 +17962,6 @@
         "libnpmteam": {
           "version": "6.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "npm-registry-fetch": "^16.0.0"
@@ -18477,7 +17970,6 @@
         "libnpmversion": {
           "version": "5.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@npmcli/git": "^5.0.3",
             "@npmcli/run-script": "^7.0.2",
@@ -18488,13 +17980,11 @@
         },
         "lru-cache": {
           "version": "10.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "make-fetch-happen": {
           "version": "13.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@npmcli/agent": "^2.0.0",
             "cacache": "^18.0.0",
@@ -18511,25 +18001,18 @@
         },
         "minimatch": {
           "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
         },
         "minipass": {
           "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-          "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "minipass-collect": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minipass": "^7.0.3"
           }
@@ -18537,7 +18020,6 @@
         "minipass-fetch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "encoding": "^0.1.13",
             "minipass": "^7.0.3",
@@ -18548,7 +18030,6 @@
         "minipass-flush": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minipass": "^3.0.0"
           },
@@ -18556,7 +18037,6 @@
             "minipass": {
               "version": "3.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "yallist": "^4.0.0"
               }
@@ -18566,7 +18046,6 @@
         "minipass-json-stream": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "jsonparse": "^1.3.1",
             "minipass": "^3.0.0"
@@ -18575,7 +18054,6 @@
             "minipass": {
               "version": "3.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "yallist": "^4.0.0"
               }
@@ -18585,7 +18063,6 @@
         "minipass-pipeline": {
           "version": "1.2.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minipass": "^3.0.0"
           },
@@ -18593,7 +18070,6 @@
             "minipass": {
               "version": "3.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "yallist": "^4.0.0"
               }
@@ -18603,7 +18079,6 @@
         "minipass-sized": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minipass": "^3.0.0"
           },
@@ -18611,7 +18086,6 @@
             "minipass": {
               "version": "3.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "yallist": "^4.0.0"
               }
@@ -18621,7 +18095,6 @@
         "minizlib": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minipass": "^3.0.0",
             "yallist": "^4.0.0"
@@ -18630,7 +18103,6 @@
             "minipass": {
               "version": "3.3.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "yallist": "^4.0.0"
               }
@@ -18639,28 +18111,23 @@
         },
         "mkdirp": {
           "version": "1.0.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ms": {
           "version": "2.1.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "mute-stream": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "negotiator": {
           "version": "0.6.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "node-gyp": {
           "version": "10.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "exponential-backoff": "^3.1.1",
@@ -18677,17 +18144,13 @@
         "nopt": {
           "version": "7.2.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "abbrev": "^2.0.0"
           }
         },
         "normalize-package-data": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
-          "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "hosted-git-info": "^7.0.0",
             "is-core-module": "^2.8.1",
@@ -18697,13 +18160,11 @@
         },
         "npm-audit-report": {
           "version": "5.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "npm-bundled": {
           "version": "3.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "npm-normalize-package-bin": "^3.0.0"
           }
@@ -18711,20 +18172,17 @@
         "npm-install-checks": {
           "version": "6.3.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "semver": "^7.1.1"
           }
         },
         "npm-normalize-package-bin": {
           "version": "3.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "npm-package-arg": {
           "version": "11.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "hosted-git-info": "^7.0.0",
             "proc-log": "^3.0.0",
@@ -18735,7 +18193,6 @@
         "npm-packlist": {
           "version": "8.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ignore-walk": "^6.0.4"
           }
@@ -18743,7 +18200,6 @@
         "npm-pick-manifest": {
           "version": "9.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "npm-install-checks": "^6.0.0",
             "npm-normalize-package-bin": "^3.0.0",
@@ -18754,7 +18210,6 @@
         "npm-profile": {
           "version": "9.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "npm-registry-fetch": "^16.0.0",
             "proc-log": "^3.0.0"
@@ -18763,7 +18218,6 @@
         "npm-registry-fetch": {
           "version": "16.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "make-fetch-happen": "^13.0.0",
             "minipass": "^7.0.2",
@@ -18776,13 +18230,11 @@
         },
         "npm-user-validate": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "npmlog": {
           "version": "7.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "are-we-there-yet": "^4.0.0",
             "console-control-strings": "^1.1.0",
@@ -18793,7 +18245,6 @@
         "p-map": {
           "version": "4.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aggregate-error": "^3.0.0"
           }
@@ -18801,7 +18252,6 @@
         "pacote": {
           "version": "17.0.6",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@npmcli/git": "^5.0.0",
             "@npmcli/installed-package-contents": "^2.0.1",
@@ -18826,7 +18276,6 @@
         "parse-conflict-json": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "json-parse-even-better-errors": "^3.0.0",
             "just-diff": "^6.0.0",
@@ -18835,17 +18284,11 @@
         },
         "path-key": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "path-scurry": {
           "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
-          "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "lru-cache": "^9.1.1 || ^10.0.0",
             "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -18854,7 +18297,6 @@
         "postcss-selector-parser": {
           "version": "6.0.15",
           "bundled": true,
-          "dev": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -18862,29 +18304,23 @@
         },
         "proc-log": {
           "version": "3.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "promise-all-reject-late": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "promise-call-limit": {
           "version": "3.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "promise-retry": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "err-code": "^2.0.2",
             "retry": "^0.12.0"
@@ -18893,34 +18329,28 @@
         "promzard": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "read": "^2.0.0"
           }
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "read": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "mute-stream": "~1.0.0"
           }
         },
         "read-cmd-shim": {
           "version": "4.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "read-package-json": {
           "version": "7.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "glob": "^10.2.2",
             "json-parse-even-better-errors": "^3.0.0",
@@ -18931,7 +18361,6 @@
         "read-package-json-fast": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "json-parse-even-better-errors": "^3.0.0",
             "npm-normalize-package-bin": "^3.0.0"
@@ -18939,21 +18368,15 @@
         },
         "retry": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "semver": {
           "version": "7.5.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           },
@@ -18961,7 +18384,6 @@
             "lru-cache": {
               "version": "6.0.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "yallist": "^4.0.0"
               }
@@ -18970,39 +18392,26 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "shebang-command": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "shebang-regex": "^3.0.0"
           }
         },
         "shebang-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "signal-exit": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "sigstore": {
           "version": "2.2.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@sigstore/bundle": "^2.1.1",
             "@sigstore/core": "^0.2.0",
@@ -19014,13 +18423,11 @@
         },
         "smart-buffer": {
           "version": "4.2.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "socks": {
           "version": "2.7.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ip": "^2.0.0",
             "smart-buffer": "^4.2.0"
@@ -19029,7 +18436,6 @@
         "socks-proxy-agent": {
           "version": "8.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "agent-base": "^7.0.2",
             "debug": "^4.3.4",
@@ -19038,10 +18444,7 @@
         },
         "spdx-correct": {
           "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-          "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
@@ -19049,15 +18452,11 @@
         },
         "spdx-exceptions": {
           "version": "2.3.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "spdx-expression-parse": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-          "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -19065,23 +18464,18 @@
         },
         "spdx-license-ids": {
           "version": "3.0.16",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ssri": {
           "version": "10.0.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minipass": "^7.0.3"
           }
         },
         "string-width": {
           "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -19090,10 +18484,7 @@
         },
         "string-width-cjs": {
           "version": "npm:string-width@4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -19102,33 +18493,25 @@
         },
         "strip-ansi": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
           }
         },
         "strip-ansi-cjs": {
           "version": "npm:strip-ansi@6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
           }
         },
         "supports-color": {
           "version": "9.4.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "tar": {
           "version": "6.2.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -19141,7 +18524,6 @@
             "fs-minipass": {
               "version": "2.1.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "minipass": "^3.0.0"
               },
@@ -19149,7 +18531,6 @@
                 "minipass": {
                   "version": "3.3.6",
                   "bundled": true,
-                  "dev": true,
                   "requires": {
                     "yallist": "^4.0.0"
                   }
@@ -19158,32 +18539,25 @@
             },
             "minipass": {
               "version": "5.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "treeverse": {
           "version": "3.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "tuf-js": {
           "version": "2.2.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@tufjs/models": "2.0.0",
             "debug": "^4.3.4",
@@ -19193,7 +18567,6 @@
         "unique-filename": {
           "version": "3.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "unique-slug": "^4.0.0"
           }
@@ -19201,22 +18574,17 @@
         "unique-slug": {
           "version": "4.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
@@ -19225,21 +18593,17 @@
         "validate-npm-package-name": {
           "version": "5.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "builtins": "^5.0.0"
           }
         },
         "walk-up-path": {
           "version": "3.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "wcwidth": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
           "bundled": true,
-          "dev": true,
           "requires": {
             "defaults": "^1.0.3"
           }
@@ -19247,32 +18611,26 @@
         "which": {
           "version": "4.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "isexe": "^3.1.1"
           },
           "dependencies": {
             "isexe": {
               "version": "3.1.1",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "wide-align": {
           "version": "1.1.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "string-width": "^1.0.2 || 2 || 3 || 4"
           }
         },
         "wrap-ansi": {
           "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-          "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ansi-styles": "^6.1.0",
             "string-width": "^5.0.1",
@@ -19281,22 +18639,15 @@
           "dependencies": {
             "ansi-regex": {
               "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-              "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "emoji-regex": {
               "version": "9.2.2",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-              "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "string-width": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "eastasianwidth": "^0.2.0",
                 "emoji-regex": "^9.2.2",
@@ -19305,10 +18656,7 @@
             },
             "strip-ansi": {
               "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-              "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "ansi-regex": "^6.0.1"
               }
@@ -19317,10 +18665,7 @@
         },
         "wrap-ansi-cjs": {
           "version": "npm:wrap-ansi@7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
             "string-width": "^4.1.0",
@@ -19330,7 +18675,6 @@
             "ansi-styles": {
               "version": "4.3.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "color-convert": "^2.0.1"
               }
@@ -19340,7 +18684,6 @@
         "write-file-atomic": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4",
             "signal-exit": "^4.0.1"
@@ -19348,10 +18691,7 @@
         },
         "yallist": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "jest": {
     "testEnvironment": "node",
-    "testRegex": "(/__tests__/.*\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(src/__tests__/.*\\.(test|spec))\\.(ts|tsx|js)$",
     "collectCoverageFrom": [
       "src/**/*.ts"
     ],

--- a/src/__tests__/find-controllers.test.ts
+++ b/src/__tests__/find-controllers.test.ts
@@ -1,8 +1,11 @@
-import { findControllers } from '../find-controllers'
+import { FindControllersResult, findControllers } from '../find-controllers'
 
 describe('findControllers', () => {
-  it('returns the classes from the fixtures', () => {
-    const result = findControllers('__fixtures__/*.js', { absolute: true })
+  it('(sync) returns the classes from the fixtures', () => {
+    const result = findControllers('__fixtures__/*.js', {
+      absolute: true,
+    })
+
     const moduleExports = result.find((x: any) => x.target.isModuleExports)
     const defaultExports = result.find((x: any) => x.target.isDefaultExport)
     const namedExports = result.find((x: any) => x.target.isNamedExport)
@@ -30,5 +33,40 @@ describe('findControllers', () => {
     expect(typeof (mixedModuleExports as any).target).toBe('function')
     expect(mixedModuleDefaultExports).toBeUndefined()
     expect(mixedModuleNamedExports).toBeUndefined()
+  })
+
+  it('(async) returns the classes from the fixtures', async () => {
+    const result = await findControllers('__fixtures__/*.js', {
+      absolute: true,
+      esModules: true,
+    })
+
+    const moduleExports = result.find((x: any) => x.target.isModuleExports)
+    const defaultExports = result.find((x: any) => x.target.isDefaultExport)
+    const namedExports = result.find((x: any) => x.target.isNamedExport)
+    const mixedDefaultExports = result.find(
+      (x: any) => x.target.isMixedDefaultExport,
+    )
+    const mixedNamedExports = result.find(
+      (x: any) => x.target.isMixedNamedExport,
+    )
+    const mixedModuleExports = result.find(
+      (x: any) => x.target.isMixedModuleExports,
+    )
+    const mixedModuleDefaultExports = result.find(
+      (x: any) => x.target.isMixedModuleDefaultExport,
+    )
+    const mixedModuleNamedExports = result.find(
+      (x: any) => x.target.isMixedModuleNamedExport,
+    )
+    expect(result.length).toBe(5)
+    expect(typeof (moduleExports as any).target).toBe('function')
+    expect(typeof (namedExports as any).target).toBe('function')
+    expect(typeof (mixedNamedExports as any).target).toBe('function')
+    expect(typeof (mixedModuleExports as any).target).toBe('function')
+    expect(typeof (mixedModuleNamedExports as any).target).toBe('function')
+    expect(defaultExports).toBeUndefined()
+    expect(mixedModuleDefaultExports).toBeUndefined()
+    expect(mixedDefaultExports).toBeUndefined()
   })
 })

--- a/src/find-controllers.ts
+++ b/src/find-controllers.ts
@@ -1,44 +1,69 @@
 import * as glob from 'fast-glob'
+
 import { IStateAndTarget, getStateAndTarget } from './state-util'
+
+/**
+ * Find Controllers options for module finding and import resolution.
+ */
+export type FindControllersOptions<ESM extends boolean = false> =
+  glob.Options & { esModules?: ESM }
 
 /**
  * Find Controllers result.
  */
 export type FindControllersResult = Array<IStateAndTarget>
 
+export function findControllers<ESM extends boolean = false>(
+  pattern: string,
+  opts?: FindControllersOptions<ESM>,
+): ESM extends true ? Promise<FindControllersResult> : FindControllersResult
 /**
  * Finds classes using the specified pattern and options.
  *
  * @param pattern Glob pattern
- * @param opts Glob options
+ * @param opts Glob options and ES modules dynamic import module loading
  */
-export function findControllers(
+export function findControllers<ESM extends boolean>(
   pattern: string,
-  opts?: glob.Options,
-): FindControllersResult {
+  opts?: FindControllersOptions<ESM>,
+): Promise<FindControllersResult> | FindControllersResult {
   const result = glob.sync(pattern, opts)
-  return result
-    .map((path) => {
-      const items: Array<IStateAndTarget | null> = []
 
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const required = require(path)
+  if (opts && opts.esModules === true) {
+    return Promise.all(
+      result.map((path) => import(path).then(extractStateAndTargetFromExports)),
+    ).then((controllers) =>
+      controllers.reduce((acc, cur) => acc.concat(cur), []),
+    )
+  } else {
+    return result
+      .map((path) => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const exports = require(path)
+        return extractStateAndTargetFromExports(exports)
+      })
+      .reduce((acc, cur) => acc.concat(cur), [])
+  }
+}
 
-      if (required) {
-        const stateAndTarget = getStateAndTarget(required)
-        if (stateAndTarget) {
-          items.push(stateAndTarget)
-          return items
-        }
+function extractStateAndTargetFromExports(exports: any): FindControllersResult {
+  const items: FindControllersResult = []
 
-        // loop through exports - this will cover named as well as a default export
-        for (const key of Object.keys(required)) {
-          items.push(getStateAndTarget(required[key]))
-        }
-      }
-
+  if (exports) {
+    const stateAndTarget = getStateAndTarget(exports)
+    if (stateAndTarget) {
+      items.push(stateAndTarget)
       return items
-    })
-    .reduce((acc, cur) => acc.concat(cur), [])
-    .filter((x) => x !== null) as FindControllersResult
+    }
+
+    // loop through exports - this will cover named as well as a default export
+    for (const key of Object.keys(exports)) {
+      const stateAndTarget = getStateAndTarget(exports[key])
+      if (stateAndTarget) {
+        items.push(stateAndTarget)
+      }
+    }
+  }
+
+  return items
 }


### PR DESCRIPTION
When run in a sync environment/ non-modern ESM module loading, the code path remains unchanged.

When loaded from an ESM environment, the call to `find-controllers` returns a `Promise` that loads the modules via dynamic `import()`, resolving the controllers in the same way as non-module once loaded.

The new feature is enabled by passing a third parameter `esmModules` to the function. This could be an options object instead, to allow for flexibility for more options in future. The current glob `opts` parameter could be repurposed, but is left as-is.

Tests updated (and small change to jest test regex to be more specific).

Slight improvement to the code to remove an unnecessary filter of `null` results.